### PR TITLE
Fix missing tabs permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
       "128": "icon16.png"
     }
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
   "host_permissions": [],
   "icons": {
     "16": "icon16.png",


### PR DESCRIPTION
## Summary
- add `tabs` permission to manifest

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('manifest.json','utf8')); console.log('JSON ok');"`


------
https://chatgpt.com/codex/tasks/task_e_683ffa57042083229533e08ac6627433