### PR TITLE
Implement circular progress gauge

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,15 +48,15 @@
   <section id="overview">
     <h2>Spendenübersicht</h2>
     <div class="charts">
-      <canvas id="goalChart"></canvas>
-      <canvas id="donationChart"></canvas>
-    </div>
-    <!-- animierte Fortschrittsanzeige -->
-    <div class="progress-container">
-      <div class="progress-bar">
-        <div class="progress-fill" id="progressFill"></div>
+      <div class="progress-container" id="progressContainer">
+        <svg class="progress-svg" viewBox="0 0 200 200">
+          <circle class="progress-bg" cx="100" cy="100" r="90" />
+          <circle class="progress-bar-circle" id="progressCircle" cx="100" cy="100" r="90" />
+        </svg>
+        <div class="progress-label" id="progressText"></div>
+        <div class="goal-amount" id="goalAmount"></div>
       </div>
-      <span id="progressText"></span>
+      <canvas id="donationChart"></canvas>
     </div>
     <div class="summary">
       <div class="box"><strong>Dein Beitrag (Mai):</strong> 120,00 €</div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,5 @@
 DocumentReady(function(){
   const barCtx = document.getElementById('donationChart');
-  const progressCtx = document.getElementById('goalChart');
   if(barCtx){
     const monthly = [4300,5200,6100,4800,5900,6700,5500,6200,5300,6100,4900,6600];
     new Chart(barCtx, {
@@ -20,26 +19,6 @@ DocumentReady(function(){
       }
     });
   }
-  if(progressCtx){
-    const own = 120;
-    const goal = 1000;
-    new Chart(progressCtx, {
-      type: 'doughnut',
-      data: {
-        labels: ['Dein Beitrag','Ziel'],
-        datasets: [{
-          data: [own, goal-own],
-          backgroundColor: ['rgba(10,62,98,0.8)','rgba(10,62,98,0.2)'],
-          borderWidth: 0
-        }]
-      },
-      options: {
-        maintainAspectRatio: false,
-        cutout: '70%',
-        plugins: { legend: { display:false } }
-      }
-    });
-  }
 });
 
 DocumentReady(function(){
@@ -50,16 +29,22 @@ DocumentReady(function(){
 });
 
 DocumentReady(function(){
-  const fill = document.getElementById('progressFill');
+  const arc = document.getElementById('progressCircle');
   const text = document.getElementById('progressText');
-  if(fill && text){
+  const goalAmount = document.getElementById('goalAmount');
+  if(arc && text && goalAmount){
     const current = 120;
     const goal = 1000;
     const percent = Math.min(100, current / goal * 100);
+    const radius = arc.r.baseVal.value;
+    const circumference = 2 * Math.PI * radius;
+    arc.style.strokeDasharray = circumference;
+    arc.style.strokeDashoffset = circumference;
     requestAnimationFrame(() => {
-      fill.style.width = percent + '%';
+      arc.style.strokeDashoffset = circumference - (percent / 100) * circumference;
     });
-    text.textContent = percent.toFixed(0) + '% des Ziels erreicht';
+    text.textContent = percent.toFixed(0) + '% deines Jahresziels';
+    goalAmount.textContent = 'Ziel: ' + goal.toFixed(0) + ' \u20AC';
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -214,3 +214,53 @@ canvas {
   font-size: 14px;
   color: #333;
 }
+
+/* Kreisförmige Fortschrittsanzeige im Dashboard */
+.progress-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.progress-container#progressContainer {
+  width: 300px;
+  height: 300px;
+  position: relative;
+  margin: auto;
+}
+
+.progress-svg circle {
+  fill: none;
+  stroke-width: 20;
+}
+
+.progress-bg {
+  stroke: #e0e0e0;
+}
+
+.progress-bar-circle {
+  stroke: #4caf50;
+  stroke-linecap: round;
+  stroke-dasharray: 565.48;
+  stroke-dashoffset: 565.48;
+  transition: stroke-dashoffset 2s ease;
+}
+
+.progress-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 24px;
+  font-weight: bold;
+  color: #333;
+}
+
+.goal-amount {
+  position: absolute;
+  width: 100%;
+  bottom: 20px;
+  text-align: center;
+  font-size: 14px;
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- replace donation goal chart with a circular progress gauge
- show target amount and percentage text for yearly goal
- update styles for new gauge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404d18c8c083229c514316747be6bb