### PR TITLE
Add grid layout and sticky footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,19 +48,22 @@
   <section id="overview">
     <h2>Spendenübersicht</h2>
     <div class="charts">
-      <div class="progress-container" id="progressContainer">
-        <svg class="progress-svg" viewBox="0 0 200 200">
-          <circle class="progress-bg" cx="100" cy="100" r="90" />
-          <circle class="progress-bar-circle" id="progressCircle" cx="100" cy="100" r="90" />
-        </svg>
-        <div class="progress-label" id="progressText"></div>
-        <div class="goal-amount" id="goalAmount"></div>
+      <div class="chart-wrapper">
+        <div class="progress-container" id="progressContainer">
+          <svg class="progress-svg" viewBox="0 0 200 200">
+            <circle class="progress-bg" cx="100" cy="100" r="90" />
+            <circle class="progress-bar-circle" id="progressCircle" cx="100" cy="100" r="90" />
+          </svg>
+          <div class="progress-label" id="progressText"></div>
+          <div class="goal-amount" id="goalAmount"></div>
+        </div>
+        <div class="box"><strong>Dein Beitrag (Mai):</strong> 120,00 €</div>
       </div>
-      <canvas id="donationChart"></canvas>
-    </div>
-    <div class="summary">
-      <div class="box"><strong>Dein Beitrag (Mai):</strong> 120,00 €</div>
-      <div class="box"><strong>Impact Cart Gesamt (Mai):</strong> 5.230,00 €</div>
+      <div class="chart-wrapper">
+        <!-- Impact Cart Gesamtstand-Balkendiagramm -->
+        <canvas id="impactChart" width="600" height="400"></canvas>
+        <div class="box"><strong>Impact Cart Gesamt (Mai):</strong> 5.230,00 €</div>
+      </div>
     </div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -1,27 +1,4 @@
 DocumentReady(function(){
-  const barCtx = document.getElementById('donationChart');
-  if(barCtx){
-    const monthly = [4300,5200,6100,4800,5900,6700,5500,6200,5300,6100,4900,6600];
-    new Chart(barCtx, {
-      type: 'bar',
-      data: {
-        labels: ['Jan','Feb','Mrz','Apr','Mai','Jun','Jul','Aug','Sep','Okt','Nov','Dez'],
-        datasets: [{
-          label: 'Gesamtspenden €',
-          data: monthly,
-          backgroundColor: 'rgba(10,62,98,0.7)'
-        }]
-      },
-      options: {
-        maintainAspectRatio: false,
-        plugins: { legend: { display:false } },
-        scales: { y: { beginAtZero:true } }
-      }
-    });
-  }
-});
-
-DocumentReady(function(){
   const track = document.querySelector('.carousel-track');
   if(track){
     track.innerHTML += track.innerHTML;
@@ -45,6 +22,48 @@ DocumentReady(function(){
     });
     text.textContent = percent.toFixed(0) + '% deines Jahresziels';
     goalAmount.textContent = 'Ziel: ' + goal.toFixed(0) + ' \u20AC';
+  }
+});
+
+DocumentReady(function(){
+  const ctx = document.getElementById('impactChart');
+  if(ctx){
+    const monate = ['Januar','Februar','M\u00e4rz','April','Mai','Juni'];
+    const gesamtStand = [1200,2500,4100,5800,7000,8300];
+    new Chart(ctx.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: monate,
+        datasets: [{
+          label: 'Impact Cart Gesamtstand (\u20AC)',
+          data: gesamtStand,
+          backgroundColor: '#ff9800',
+          borderRadius: 4,
+          barThickness: 40
+        }]
+      },
+      options: {
+        animation: {
+          duration: 2000,
+          easing: 'easeOutQuart'
+        },
+        scales: {
+          x: { title: { display: true, text: 'Monat' } },
+          y: {
+            beginAtZero: true,
+            title: { display: true, text: 'Gesamtbetrag (\u20AC)' }
+          }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: ctx => `${ctx.parsed.y.toLocaleString()} \u20AC`
+            }
+          }
+        }
+      }
+    });
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -8,6 +8,9 @@ body {
   padding: 0;
   line-height: 1.6;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 header {
@@ -92,22 +95,24 @@ section {
   margin: 0 auto;
 }
 
-.summary {
+.chart-wrapper {
   display: flex;
-  justify-content: space-around;
-  margin-top: 10px;
+  flex-direction: column;
+  align-items: center;
 }
 
-.summary .box {
+.chart-wrapper .box {
   background: #f2f2f2;
   padding: 10px;
   border-radius: 5px;
+  margin-top: 10px;
 }
 
 footer {
   background: #f2f2f2;
   text-align: center;
   padding: 10px 0;
+  margin-top: auto;
 }
 
 footer a {
@@ -161,11 +166,12 @@ canvas {
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
 }
 
+
 .charts {
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  justify-items: center;
+  gap: 40px;
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
## Summary
- restructure dashboard so gauge and total chart sit in a grid
- center labels for gauge and bar chart with spacing
- switch footer to sticky layout so it stays at the window bottom

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68404e6c661c832292404ec56452547a