### PR TITLE
Synchronize popup progress with annual goal

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -63,7 +63,7 @@ h1, h2 { margin:0 0 10px; font-size:18px; }
 label, select { display:block; margin:5px 0; width:100%; }
 select { padding:5px; }
 .progress-bar { width:100%; height:8px; background:#eee; margin:10px 0; }
-#progress { width:0; height:100%; background:#888; }
+#progress { width:0; height:100%; background:#888; transition:width 1s ease; }
 #amount { font-size:14px; }
 .footer { font-size:10px; display:flex; justify-content:space-between; margin-top:10px; }
 .footer a { text-decoration:none; cursor:pointer; }

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-const TARGET = 100;
+let TARGET = 100;
 
 document.addEventListener('DOMContentLoaded', () => {
   const loginC = document.getElementById('login-container');
@@ -31,10 +31,11 @@ document.addEventListener('DOMContentLoaded', () => {
   function initMain() {
     mainC.style.display = 'block';
     // lade Zustand
-    chrome.storage.sync.get(['active','charity','collected'], data => {
-      const active   = data.active || false;
-      const charity  = data.charity || sel.value;
-      const collected= data.collected || 6.37;
+    chrome.storage.sync.get(['active','charity','collected','yearGoal'], data => {
+      const active    = data.active || false;
+      const charity   = data.charity || sel.value;
+      const collected = data.collected || 0;
+      TARGET          = data.yearGoal || TARGET;
       sel.value = charity;
       btn.textContent = active?'SPENDEN AKTIVIERT':'SPENDEN AKTIVIEREN';
       btn.classList.toggle('active', active);
@@ -67,7 +68,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updateProgress(value) {
     const pct = Math.min(100, value/TARGET*100);
-    prog.style.width = pct+'%';
+    prog.style.width = '0';
+    requestAnimationFrame(() => {
+      prog.style.width = pct + '%';
+    });
     amt.textContent = `Dein Beitrag: ${value.toFixed(2)} € gesammelt`;
   }
 });

--- a/script.js
+++ b/script.js
@@ -13,6 +13,9 @@ DocumentReady(function(){
     const current = 120;
     const goal = 200;
     const percent = Math.min(100, current / goal * 100);
+    if (typeof chrome !== 'undefined' && chrome.storage) {
+      chrome.storage.sync.set({ collected: current, yearGoal: goal });
+    }
     const radius = arc.r.baseVal.value;
     const circumference = 2 * Math.PI * radius;
     arc.style.strokeDasharray = circumference;


### PR DESCRIPTION
## Summary
- store annual progress data on dashboard load
- read goal and collected amount in the popup
- animate popup progress bar to collected amount

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68406a4be6d883228009342dadd3f8d6