### PR TITLE
Implement affiliate link backend

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,30 @@
+// background.js
+
+// Sobald auf den Extension-Button geklickt wird:
+chrome.action.onClicked.addListener((tab) => {
+  // Injektion der Funktion replaceAffiliateLinks in den aktuellen Tab
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: replaceAffiliateLinks
+  });
+});
+
+// Funktion, die in der Seite läuft und Links ersetzt
+function replaceAffiliateLinks() {
+  // Fest definiertes Produkt (Beispiel-ASIN)
+  const produktUrl = "https://www.amazon.de/dp/B08N5WRWNW";
+  const affiliateUrl = produktUrl + "/?tag=affiliate-tag-20";
+
+  // Alle <a>-Elemente prüfen
+  document.querySelectorAll("a[href]").forEach(a => {
+    // Basis-URL (ohne Query-Parameter) extrahieren
+    const basis = a.href.split("?")[0];
+    if (basis === produktUrl) {
+      a.href = affiliateUrl;
+    }
+  });
+
+  // Optional: Rückmeldung in der Konsole
+  console.log("Affiliate-Link ersetzt: ", affiliateUrl);
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,16 +3,21 @@
   "name": "Gutes tun beim Einkaufen",
   "version": "1.0",
   "description": "Dummy-Extension mit Login & Landing-Pages",
+  "permissions": ["storage", "tabs", "scripting", "activeTab"],
+  "host_permissions": [
+    "https://www.amazon.de/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
-    "default_popup": "popup.html",
+    "default_title": "Affiliate aktivieren",
     "default_icon": {
       "16": "icon16.png",
       "48": "icon16.png",
       "128": "icon16.png"
     }
   },
-  "permissions": ["storage", "tabs"],
-  "host_permissions": [],
   "icons": {
     "16": "icon16.png",
     "48": "icon16.png",


### PR DESCRIPTION
## Summary
- add background script to replace specific Amazon links with affiliate version
- update manifest to use service worker and necessary permissions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406c1f9b4c8322bec6cbc3f0d350ff