### PR TITLE
Implement affiliate link backend

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,31 @@
+// background.js
+
+// Empfängt Nachrichten vom Popup zum Ersetzen von Links
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'replaceLinks' && msg.tabId) {
+    chrome.scripting.executeScript({
+      target: { tabId: msg.tabId },
+      func: replaceAffiliateLinks
+    });
+  }
+});
+
+// Funktion, die in der Seite läuft und Links ersetzt
+function replaceAffiliateLinks() {
+  // Fest definiertes Produkt (Beispiel-ASIN)
+  const produktUrl = "https://www.amazon.de/dp/B08N5WRWNW";
+  const affiliateUrl = produktUrl + "/?tag=affiliate-tag-20";
+
+  // Alle <a>-Elemente prüfen
+  document.querySelectorAll("a[href]").forEach(a => {
+    // Basis-URL (ohne Query-Parameter) extrahieren
+    const basis = a.href.split("?")[0];
+    if (basis === produktUrl) {
+      a.href = affiliateUrl;
+    }
+  });
+
+  // Optional: Rückmeldung in der Konsole
+  console.log("Affiliate-Link ersetzt: ", affiliateUrl);
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,13 @@
   "name": "Gutes tun beim Einkaufen",
   "version": "1.0",
   "description": "Dummy-Extension mit Login & Landing-Pages",
+  "permissions": ["storage", "tabs", "scripting", "activeTab"],
+  "host_permissions": [
+    "https://www.amazon.de/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -11,8 +18,6 @@
       "128": "icon16.png"
     }
   },
-  "permissions": ["storage", "tabs"],
-  "host_permissions": [],
   "icons": {
     "16": "icon16.png",
     "48": "icon16.png",

--- a/popup.js
+++ b/popup.js
@@ -48,6 +48,13 @@ document.addEventListener('DOMContentLoaded', () => {
         chrome.storage.sync.set({active:next});
         btn.textContent = next?'SPENDEN AKTIVIERT':'SPENDEN AKTIVIEREN';
         btn.classList.toggle('active', next);
+        if(next){
+          chrome.tabs.query({active:true, currentWindow:true}, tabs=>{
+            if(tabs.length){
+              chrome.runtime.sendMessage({action:'replaceLinks', tabId:tabs[0].id});
+            }
+          });
+        }
       });
     });
     sel.addEventListener('change', ()=>chrome.storage.sync.set({charity:sel.value}));


### PR DESCRIPTION
## Summary
- add background script to replace specific Amazon links with affiliate version
- update manifest to use service worker and necessary permissions
- reinstate popup.html as default action and send message to background when toggling donations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68406c1f9b4c8322bec6cbc3f0d350ff