### PR TITLE
Implement automatic link replacement

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,11 +10,26 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
+// Führt das Ersetzen automatisch nach jedem vollständigen Seitenaufruf aus
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete') {
+    chrome.storage.sync.get('active', d => {
+      if (d.active && tab.url && tab.url.startsWith('https://www.amazon.de/')) {
+        chrome.scripting.executeScript({
+          target: { tabId },
+          func: replaceAffiliateLinks
+        });
+      }
+    });
+  }
+});
+
 // Funktion, die in der Seite läuft und Links ersetzt
 function replaceAffiliateLinks() {
-  // Fest definiertes Produkt (Beispiel-ASIN)
-  const produktUrl = "https://www.amazon.de/dp/B08N5WRWNW";
-  const affiliateUrl = produktUrl + "/?tag=affiliate-tag-20";
+  // Fest definierter Test-Link
+  const produktUrl =
+    "https://www.amazon.de/Anker-Powerbank-Powerstation-Solargenerator-Lieferumfang/dp/B0D62PMB3R/";
+  const affiliateUrl = produktUrl + "?tag=affiliate-tag-20";
 
   // Alle <a>-Elemente prüfen
   document.querySelectorAll("a[href]").forEach(a => {


### PR DESCRIPTION
## Summary
- trigger affiliate link replacement whenever an amazon tab finishes loading
- update test link in the replacement logic

## Testing
- `node -e "const produktUrl =\n'https://www.google.com'; console.log(produktUrl);"` *(fails: SyntaxError)*
- `node - <<'EOF'
const produktUrl =
'https://www.google.com';
console.log(produktUrl);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68415683eb8c8322934bb0d1f919b9ca